### PR TITLE
Updated MCC version details in main.json

### DIFF
--- a/active_scan/firmware/active_scan_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
+++ b/active_scan/firmware/active_scan_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
@@ -21,8 +21,8 @@
 			"semverRange": "^1.6.220"
 		},
 		"configurator": {
-			"name": "MHC",
-			"semverRange": ">=3.8.5"
+			"name": "MCC",
+			"semverRange": ">=5.1.17"
 		},
 		"device": {
 			"metaDataVersion": "1.0.0",
@@ -39,7 +39,7 @@
 			"Wi-Fi"
 		],
 		"keywords": [
-			"MHC",
+			"MCC",
 			"Harmony",
 			"PIC32MZ1025W104132",
 			"WFI32",

--- a/ap_auto_channel/firmware/ap_auto_channel_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
+++ b/ap_auto_channel/firmware/ap_auto_channel_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
@@ -21,8 +21,8 @@
 			"semverRange": "^1.6.220"
 		},
 		"configurator": {
-			"name": "MHC",
-			"semverRange": ">=3.8.5"
+			"name": "MCC",
+			"semverRange": ">=5.1.17"
 		},
 		"device": {
 			"metaDataVersion": "1.0.0",
@@ -39,7 +39,7 @@
 			"Wi-Fi"
 		],
 		"keywords": [
-			"MHC",
+			"MCC",
 			"Harmony",
 			"PIC32MZ1025W104132",
 			"WFI32",

--- a/directed_active_scan/firmware/directed_active_scan_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
+++ b/directed_active_scan/firmware/directed_active_scan_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
@@ -21,8 +21,8 @@
 			"semverRange": "^1.6.220"
 		},
 		"configurator": {
-			"name": "MHC",
-			"semverRange": ">=3.8.5"
+			"name": "MCC",
+			"semverRange": ">=5.1.17"
 		},
 		"device": {
 			"metaDataVersion": "1.0.0",
@@ -39,7 +39,7 @@
 			"Wi-Fi"
 		],
 		"keywords": [
-			"MHC",
+			"MCC",
 			"Harmony",
 			"PIC32MZ1025W104132",
 			"WFI32",

--- a/passive_scan/firmware/passive_scan_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
+++ b/passive_scan/firmware/passive_scan_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
@@ -21,8 +21,8 @@
 			"semverRange": "^1.6.220"
 		},
 		"configurator": {
-			"name": "MHC",
-			"semverRange": ">=3.8.5"
+			"name": "MCC",
+			"semverRange": ">=5.1.17"
 		},
 		"device": {
 			"metaDataVersion": "1.0.0",
@@ -39,7 +39,7 @@
 			"Wi-Fi"
 		],
 		"keywords": [
-			"MHC",
+			"MCC",
 			"Harmony",
 			"PIC32MZ1025W104132",
 			"WFI32",

--- a/pic32mzw1_kitprotocol/firmware/kitprotocol.X/.main-meta/main.json
+++ b/pic32mzw1_kitprotocol/firmware/kitprotocol.X/.main-meta/main.json
@@ -21,8 +21,8 @@
 			"semverRange": "^1.6.220"
 		},
 		"configurator": {
-			"name": "MHC",
-			"semverRange": ">=3.8.5"
+			"name": "MCC",
+			"semverRange": ">=5.1.17"
 		},
 		"device": {
 			"metaDataVersion": "1.0.0",
@@ -39,7 +39,7 @@
 			"Wi-Fi"
 		],
 		"keywords": [
-			"MHC",
+			"MCC",
 			"Harmony",
 			"PIC32MZ1025W104132",
 			"WFI32",

--- a/wifi_eth_routing/firmware/pic32mz_w1_curiosity_freertos_routing.X/.main-meta/main.json
+++ b/wifi_eth_routing/firmware/pic32mz_w1_curiosity_freertos_routing.X/.main-meta/main.json
@@ -21,8 +21,8 @@
 			"semverRange": "^1.6.220"
 		},
 		"configurator": {
-			"name": "MHC",
-			"semverRange": ">=3.8.5"
+			"name": "MCC",
+			"semverRange": ">=5.1.17"
 		},
 		"device": {
 			"metaDataVersion": "1.0.0",
@@ -39,7 +39,7 @@
 			"Wi-Fi"
 		],
 		"keywords": [
-			"MHC",
+			"MCC",
 			"Harmony",
 			"PIC32MZ1025W104132",
 			"WFI32",

--- a/wifi_peripherals_init/firmware/init_time_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
+++ b/wifi_peripherals_init/firmware/init_time_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
@@ -21,8 +21,8 @@
 			"semverRange": "^1.6.220"
 		},
 		"configurator": {
-			"name": "MHC",
-			"semverRange": ">=3.8.5"
+			"name": "MCC",
+			"semverRange": ">=5.1.17"
 		},
 		"device": {
 			"metaDataVersion": "1.0.0",
@@ -39,7 +39,7 @@
 			"Wi-Fi"
 		],
 		"keywords": [
-			"MHC",
+			"MCC",
 			"Harmony",
 			"PIC32MZ1025W104132",
 			"WFI32",

--- a/wifi_sntp_time/firmware/wifi_sntp_time_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
+++ b/wifi_sntp_time/firmware/wifi_sntp_time_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
@@ -21,8 +21,8 @@
 			"semverRange": "^1.6.220"
 		},
 		"configurator": {
-			"name": "MHC",
-			"semverRange": ">=3.8.5"
+			"name": "MCC",
+			"semverRange": ">=5.1.17"
 		},
 		"device": {
 			"metaDataVersion": "1.0.0",
@@ -39,7 +39,7 @@
 			"Wi-Fi"
 		],
 		"keywords": [
-			"MHC",
+			"MCC",
 			"Harmony",
 			"PIC32MZ1025W104132",
 			"WFI32",

--- a/wifi_timing_open/firmware/wifi_timing_open_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
+++ b/wifi_timing_open/firmware/wifi_timing_open_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
@@ -21,8 +21,8 @@
 			"semverRange": "^1.6.220"
 		},
 		"configurator": {
-			"name": "MHC",
-			"semverRange": ">=3.8.5"
+			"name": "MCC",
+			"semverRange": ">=5.1.17"
 		},
 		"device": {
 			"metaDataVersion": "1.0.0",
@@ -39,7 +39,7 @@
 			"Wi-Fi"
 		],
 		"keywords": [
-			"MHC",
+			"MCC",
 			"Harmony",
 			"PIC32MZ1025W104132",
 			"WFI32",

--- a/wifi_timing_wpa2/firmware/wifi_timing_wpa2_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
+++ b/wifi_timing_wpa2/firmware/wifi_timing_wpa2_pic32mz_w1_curiosity_freertos.X/.main-meta/main.json
@@ -21,8 +21,8 @@
 			"semverRange": "^1.6.220"
 		},
 		"configurator": {
-			"name": "MHC",
-			"semverRange": ">=3.8.5"
+			"name": "MCC",
+			"semverRange": ">=5.1.17"
 		},
 		"device": {
 			"metaDataVersion": "1.0.0",
@@ -39,7 +39,7 @@
 			"Wi-Fi"
 		],
 		"keywords": [
-			"MHC",
+			"MCC",
 			"Harmony",
 			"PIC32MZ1025W104132",
 			"WFI32",


### PR DESCRIPTION
main.json file changes for MCC configurator version details are in place. Replaced 'MHC' with 'MCC' from keyword list.